### PR TITLE
Add readme instructions for android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,19 @@ React Native Bootstrap
     - `brew install node@14`
     - `brew link node@14`
     - Follow brew instruction, like having to `--force` and `--overwrite`
+- watchman 4.9.0
+  - `brew install watchman`
 - Cocoapods 1.10.1
   - `sudo gem install cocoapods`
 - xcode-select version 2373
   - `xcode-select --install`
-- watchman 4.9.0
-  - `brew install watchman`
+- JDK 8
+  - `brew install --cask adoptopenjdk/openjdk/adoptopenjdk8`
+- Setup local env variables.
+  - Follow step [3. Configure the ANDROID_HOME environment variable](https://reactnative.dev/docs/environment-setup)
 
+### References
+- https://reactnative.dev/docs/environment-setup
 ## Local Development for iOS
 
 1. Make sure environment dependencies like Node, Cocoapods, xcode-select, and watchman are installed


### PR DESCRIPTION
Had to run `npm run android` twice, but worked the second time:
<img width="454" alt="Screen Shot 2021-03-13 at 7 13 13 PM" src="https://user-images.githubusercontent.com/1335082/111055989-97845800-8438-11eb-8ac6-05e851cdc6c7.png">
